### PR TITLE
Add deep_copy calls missing because of a Y2R bug

### DIFF
--- a/src/modules/NisServer.rb
+++ b/src/modules/NisServer.rb
@@ -328,7 +328,7 @@ module Yast
     def SCRGet(p, default_val)
       default_val = deep_copy(default_val)
       v = SCR.Read(p)
-      v != nil ? v : default_val
+      v != nil ? deep_copy(v) : deep_copy(default_val)
     end
 
     def SCRGetInt(p, default_val)


### PR DESCRIPTION
See https://github.com/yast/y2r/issues/47.
