### PR TITLE
Added command line support for Active Slave sync

### DIFF
--- a/src/clients/nis_server.rb
+++ b/src/clients/nis_server.rb
@@ -140,6 +140,14 @@ module Yast
             ),
             "type" => "string"
           },
+          "sync_slave"       => {
+           # command line help text for the 'sync_slave' option
+            "help" => _(
+              "Sync to NIS Slave servers"
+            ),
+            "type"     => "enum",
+            "typespec" => ["yes", "no"]
+          },
           "securenets" => {
             # command line help text for the 'hosts' option
             "help" => _(
@@ -150,7 +158,7 @@ module Yast
         },
         "mappings"   => {
           "summary" => [],
-          "master"  => ["domain", "yppasswd", "ypdir", "maps", "securenets"],
+          "master"  => ["domain", "yppasswd", "ypdir", "maps", "securenets", "sync_slave"],
           "slave"   => ["domain", "master_ip", "securenets"]
         }
       }
@@ -364,6 +372,10 @@ module Yast
 
       if Ops.get_string(options, "yppasswd", "") != ""
         NisServer.start_yppasswdd = Ops.get_string(options, "yppasswd", "") == "yes"
+      end
+      
+      if Ops.get_string(options, "sync_slave", "") != ""
+        NisServer.nopush = Ops.get_string(options, "sync_slave", "") == "yes"
       end
 
       NisServer.maps = deep_copy(maps)

--- a/src/include/nis_server/master.rb
+++ b/src/include/nis_server/master.rb
@@ -168,7 +168,7 @@ module Yast
               Id(:have_slave),
               # To translators: checkbox label
               _("Active Slave NIS server &exists"),
-              !nopush
+              nopush
             )
           ),
           VSpacing(0.5),


### PR DESCRIPTION
I wanted to setup master/slave nis server, but there was no command line option for me to enable the "Active Slave NIS server exists". 
If we don't enable this the data is not pushed from master to slave server, and same has said in the docs.

So this patch works great. hopping to see in next update.