### PR TITLE
 Replace SuSEFirewall2 by firewalld (fate#323460)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,13 @@ Makefile.am.common
 tmp.*
 *.log
 *.ybc
+*.bak
+.yardoc/
+/doc/autodocs/
+/testsuite/config
+/testsuite/raw.*
+/testsuite/*.sum
+/testsuite/*.exp
+/testsuite/run/runtest.sh
+/testsuite/yast2-nis-server.test/
+

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,7 @@
+--no-private
+--markup markdown
+--protected
+--readme README.md
+--output-dir ./doc/autodocs
+--files *.md
+src/**/*.rb

--- a/package/yast2-nis-server.changes
+++ b/package/yast2-nis-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Feb 20 07:45:58 UTC 2018 - knut.anderssen@suse.com
+
+- Replace SuSEFirewall2 by firewalld (fate#323460)
+- 4.0.0
+
+-------------------------------------------------------------------
 Wed Jun  1 15:07:55 UTC 2016 - igonzalezsosa@suse.com
 
 - Drop yast2-nis-server-devel-doc package (fate#320356)

--- a/package/yast2-nis-server.spec
+++ b/package/yast2-nis-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nis-server
-Version:        3.1.4
+Version:        4.0.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -25,13 +25,14 @@ Source0:        %{name}-%{version}.tar.bz2
 
 Group:          System/YaST
 License:        GPL-2.0
-BuildRequires:	doxygen perl-XML-Writer update-desktop-files yast2 yast2-network yast2-nis-client yast2-testsuite
+BuildRequires:  doxygen perl-XML-Writer update-desktop-files yast2-network yast2-nis-client yast2-testsuite
+# SuSEFirewall2 replaced by firewalld (fate#323460)
+BuildRequires:  yast2 >= 4.0.39
 BuildRequires:  yast2-devtools >= 3.1.10
-Requires:	yast2-network yast2-nis-client
+Requires:       yast2-network yast2-nis-client
 
-# NetworkInterfaces
-# Wizard::SetDesktopTitleAndIcon
-Requires:      	yast2 >= 2.21.22
+# SuSEFirewall2 replaced by firewalld (fate#323460)
+Requires:       yast2 >= 4.0.39
 
 Provides:	yast2-config-nis-server
 Obsoletes:	yast2-config-nis-server

--- a/src/include/nis_server/routines.rb
+++ b/src/include/nis_server/routines.rb
@@ -148,7 +148,7 @@ module Yast
     # Create the widget for opening firewall ports
     def GetFirewallWidget
       settings = {
-        "services"        => ["service:ypserv"],
+        "services"        => ["ypserv"],
         "display_details" => true,
         # firewall openning help
         "help"            => _(

--- a/src/modules/NisServer.rb
+++ b/src/modules/NisServer.rb
@@ -30,6 +30,7 @@
 # Representation of the configuration of nisServer.
 # Input and output routines.
 require "yast"
+require "y2firewall/firewalld"
 
 module Yast
   class NisServerClass < Module
@@ -42,7 +43,6 @@ module Yast
       Yast.import "Progress"
       Yast.import "Service"
       Yast.import "Summary"
-      Yast.import "SuSEFirewall"
 
       # Data was modified?
       @modified = false
@@ -315,9 +315,7 @@ module Yast
 
       Progress.NextStage
 
-      progress_orig = Progress.set(false)
-      SuSEFirewall.Read
-      Progress.set(progress_orig)
+      Y2Firewall::Firewalld.instance.read
 
       Progress.NextStage
 
@@ -547,9 +545,7 @@ module Yast
 
       Progress.NextStage
 
-      progress_orig = Progress.set(false)
-      SuSEFirewall.Write
-      Progress.set(progress_orig)
+      Y2Firewall::Firewalld.instance.write
 
       Progress.NextStage
       true


### PR DESCRIPTION
- [Trello Card](https://trello.com/c/99OkErr6/1093-8-firewall-firewalld-is-the-new-susefirewall-cwm)

In the past the ypserver package provided the firewall service definition but that have changed in firewalld and that is not the case anymore. Taking in account that there is not a firewalld service that fit to our needs we will need some work in the future in order to permit NIS access.

So this PR is mainly for removing SuSEFirewall2 but nothing more.