### PR TITLE
 Fix the detection of the AutoYaST client

### DIFF
--- a/package/yast2-nis-server.changes
+++ b/package/yast2-nis-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 23 12:15:34 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Set X-SuSE-YaST-AutoInstClient in the desktop file to properly
+  determine the client name (bsc#1188644).
+- 4.2.3
+
+-------------------------------------------------------------------
 Fri Feb 28 11:12:19 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Properly report in CLI whether NIS is configured or not

--- a/package/yast2-nis-server.spec
+++ b/package/yast2-nis-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nis-server
-Version:        4.2.2
+Version:        4.2.3
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/desktop/org.opensuse.yast.NISServer.desktop
+++ b/src/desktop/org.opensuse.yast.NISServer.desktop
@@ -12,6 +12,7 @@ X-SuSE-YaST-RootOnly=true
 X-SuSE-YaST-AutoInst=all
 X-SuSE-YaST-Geometry=
 X-SuSE-YaST-SortKey=
+X-SuSE-YaST-AutoInstClient=nis_server_auto
 X-SuSE-YaST-AutoInstClonable=true
 X-SuSE-YaST-AutoInstResource=nis_server
 X-SuSE-YaST-AutoInstSchema=nis_server.rnc


### PR DESCRIPTION
This PR fixes [bsc#1188644](https://bugzilla.suse.com/show_bug.cgi?id=1188644).

AutoYaST relies on `.desktop` files for several things, like finding out which client is expected to process each section of the profile. After the changes introduced in SP2 regarding the `.desktop` files, it is not possible to match `NISServer.desktop` with the client. Setting the `X-SuSE-YaST-AutoInstClient` client does the trick.

Another option would be to rename the client, but I prefer to be conservative just in case anyone is relying on it outside of the YaST team.

See https://github.com/yast/yast-nfs-server/pull/51 for the yast2-nfs-server counterpart.