### PR TITLE
Obsolete package for TW

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-# YaST - The NIS Server Module #
+Obsoleted Repository
+====================
+
+**This repository is obsoleted and it is not developed anymore.**
+
+The package *yast2-nis-server* is only maitained for *SUSE SLE 15* and *openSUSE Leap 15* products.
+No new features will be implemented and the packate will be dropped from future products. *Tumbleweed*
+does not provide this package anymore.
+
 
 [![Workflow Status](https://github.com/yast/yast-nis-server/workflows/CI/badge.svg?branch=master)](
 https://github.com/yast/yast-nis-server/actions?query=branch%3Amaster)

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 require "yast/rake"
 
+Yast::Tasks.submit_to :sle_latest
+
 Yast::Tasks.configuration do |conf|
   #lets ignore license check for now
   conf.skip_license_check << /.*/

--- a/package/yast2-nis-server.changes
+++ b/package/yast2-nis-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Mar 25 13:10:30 UTC 2022 - José Iván López González <jlopez@suse.com>
+
+- Obsolete package for Tumbleweed (bsc#1183893).
+- 4.4.3
+
+-------------------------------------------------------------------
 Fri Feb 18 12:51:37 UTC 2022 - Michal Filka <mfilka@suse.com>
 
 - bnc#1195714

--- a/package/yast2-nis-server.spec
+++ b/package/yast2-nis-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nis-server
-Version:        4.4.2
+Version:        4.4.3
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

NIS is very old and it should not be used. The package *yast2-nis-server* should not be included in TW anymore.

* https://bugzilla.suse.com/show_bug.cgi?id=1183893
* https://trello.com/c/nvcUvZ93/2896-2-drop-yast-nis-from-tw

## Solution

Only submit to SLE. Note that *yast2-nis-server* will not be removed from SLE-15 yet. It will be only maintained, no new features. Added note to README to indicate the status of this module.

Note: This PR will not be submitted to Factory because the jenkins job in ci.opensuse.org was already removed.
Note: This PR will not be merged into master yet. The temporary branch *pre-SLE-15-SP4* will be merged into master after *SLE-15-SP4* branching.